### PR TITLE
Support draweio 13.x

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -122,13 +122,13 @@ export_diagram_file() {
   # shellcheck disable=SC2086
   DRAWIO_CLI_SUPPRESS_WARNINGS=true \
     "$SCRIPT_FOLDER/cli-runner.sh" \
-    --disable-dev-shm-usage \
     -x \
     -f "$export_type" \
     $CLI_OPTIONS \
     -p "$((pagenum - 1))" \
     -o "$output_filename.$export_type" \
-    "$path"
+    "$path" \
+    --disable-dev-shm-usage 
 }
 
 create_asciidoc_page() {


### PR DESCRIPTION
Closely related to https://github.com/rlespinasse/drawio-cli/pull/5 and https://github.com/rlespinasse/drawio-cli/pull/4

This PR moves an argument to the end of the line as seems to be required by newer versions of drawio.

Without this we get a "Error: input file/directory not found" error (tested with version 13.7.3 of jgraph/drawio-desktop)