### PR TITLE
feat: support draw.io options directly

### DIFF
--- a/tests/expected/help.log
+++ b/tests/expected/help.log
@@ -2,14 +2,12 @@ Usage: drawio-export [Options]
 Options:
   -E, --fileext <fileext>           Extension of exported files (default 'pdf').
                                     pdf, png, jpg, svg, vsdx, adoc
-  -C, --cli-options <options>       Options for Draw.io CLI (default '--crop'),
-                                    see 'Draw.io CLI Options' section.
   -F, --folder <folder>             Export folder name (default 'export').
   -h, --help                        Display this help message.
   --remove-page-suffix              Remove page suffix when possible
                                     (in case of single page file)
 
-Draw.io CLI Options:
+Also support Draw.io CLI Options:
   -q, --quality <quality>           Output image quality for JPEG (default: 90).
   -t, --transparent                 Set transparent background for PNG.
   -e, --embed-diagram               Includes a copy of the diagram (for PNG format only).
@@ -21,5 +19,10 @@ Draw.io CLI Options:
 
 Environment variables:
   DRAWIO_EXPORT_FILEEXT             Same as '--fileext', will be override if '--fileext' is set.
-  DRAWIO_EXPORT_CLI_OPTIONS         Same as '--cli-options', will be override if '--cli-options' is set.
+  DRAWIO_EXPORT_CLI_OPTIONS         Options for Draw.io CLI (default '--crop'), will be override if any CLI option is set.
   DRAWIO_EXPORT_FOLDER              Same as '--export-folder', will be override if '--export-folder' is set.
+
+Deprecated Options:
+  -C, --cli-options <options>       Options for Draw.io CLI (default '--crop'),
+                                    see 'Draw.io CLI Options' section.
+                                    DEPRECATED: only support one argument.

--- a/tests/expected/help_wrong_argument.log
+++ b/tests/expected/help_wrong_argument.log
@@ -4,14 +4,12 @@ Usage: drawio-export [Options]
 Options:
   -E, --fileext <fileext>           Extension of exported files (default 'pdf').
                                     pdf, png, jpg, svg, vsdx, adoc
-  -C, --cli-options <options>       Options for Draw.io CLI (default '--crop'),
-                                    see 'Draw.io CLI Options' section.
   -F, --folder <folder>             Export folder name (default 'export').
   -h, --help                        Display this help message.
   --remove-page-suffix              Remove page suffix when possible
                                     (in case of single page file)
 
-Draw.io CLI Options:
+Also support Draw.io CLI Options:
   -q, --quality <quality>           Output image quality for JPEG (default: 90).
   -t, --transparent                 Set transparent background for PNG.
   -e, --embed-diagram               Includes a copy of the diagram (for PNG format only).
@@ -23,5 +21,10 @@ Draw.io CLI Options:
 
 Environment variables:
   DRAWIO_EXPORT_FILEEXT             Same as '--fileext', will be override if '--fileext' is set.
-  DRAWIO_EXPORT_CLI_OPTIONS         Same as '--cli-options', will be override if '--cli-options' is set.
+  DRAWIO_EXPORT_CLI_OPTIONS         Options for Draw.io CLI (default '--crop'), will be override if any CLI option is set.
   DRAWIO_EXPORT_FOLDER              Same as '--export-folder', will be override if '--export-folder' is set.
+
+Deprecated Options:
+  -C, --cli-options <options>       Options for Draw.io CLI (default '--crop'),
+                                    see 'Draw.io CLI Options' section.
+                                    DEPRECATED: only support one argument.

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -17,11 +17,11 @@
 }
 
 @test "Export as png using short options" {
-  docker_test "-E png -C -t -F test-assets-png" "" 0 "png"
+  docker_test "-E png -t -F test-assets-png" "" 0 "png"
 }
 
 @test "Export as pdf using long options" {
-  docker_test "--fileext pdf --cli-options --crop --folder test-assets-pdf" "" 0 "pdf"
+  docker_test "--fileext pdf --crop --folder test-assets-pdf" "" 0 "pdf"
 }
 
 @test "Export as adoc using environment variables" {


### PR DESCRIPTION
- `-c` is mark as deprecated
- `--cli-options`  is mark as deprecated
- all draw.io cli options are now available directly in the command line
-`DRAWIO_EXPORT_CLI_OPTIONS` env variable is override when any CLI option is set

Closes #19 