### PR TITLE
ci: expand token scope to enable workflow on release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,3 +42,4 @@ jobs:
         uses: rlespinasse/release-that@v1.x
         with:
           without-prefix: true
+          github-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Linked to rlespinasse/release-that#14 and the docker image publication workflow on new release