### PR TITLE
fix: use previous election security warning filtering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM rust:buster as drawio-exporter-installer
 
 RUN cargo install --version 1.2.0 drawio-exporter
 
-FROM rlespinasse/drawio-desktop-headless:v1.7.0
+FROM rlespinasse/drawio-desktop-headless:v1.7.1
 
 WORKDIR /opt/drawio-exporter
 COPY --from=drawio-exporter-installer /usr/local/cargo/bin/drawio-exporter .

--- a/scripts/runner.sh
+++ b/scripts/runner.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 if [ "${ELECTRON_DISABLE_SECURITY_WARNINGS}" == "true" ]; then
-  "$DRAWIO_DESKTOP_EXECUTABLE_PATH" --drawio-desktop-headless "$@" 3>&1 >&2 2>&3 3>&- |
+  "$DRAWIO_DESKTOP_EXECUTABLE_PATH" --drawio-desktop-headless "$@" 2>&1 |
     grep -v "Failed to connect to socket" |
     grep -v "Could not parse server address" |
     grep -v "Floss manager not present" |
     grep -v "Exiting GPU process" |
     grep -v "called with multiple threads" |
     grep -v "extension not supported" |
-    grep -v "Failed to send GpuControl.CreateCommandBuffer"
+    grep -v "Failed to send GpuControl.CreateCommandBuffer" |
+    grep -v "Init observer found at shutdown"
 else
   "$DRAWIO_DESKTOP_EXECUTABLE_PATH" --drawio-desktop-headless "$@" 2>&1
 fi

--- a/tests/base.bats
+++ b/tests/base.bats
@@ -11,10 +11,10 @@ docker_test() {
   shift
   run docker container run -t $docker_opts -w /data -v $(pwd)/${data_folder:-}:/data ${DOCKER_IMAGE} "$@"
 
-  echo "$output" > "tests/output/$output_file.log"
+  echo "$output" | tee "tests/output/$output_file.log" | sed 's#\[.*:.*/.*\..*:.*:.*\(.*\)\] ##' >"tests/output/$output_file-comp.log"
 
   [ "$status" -eq $status ]
   if [ -f "tests/expected/$output_file.log" ]; then
-    [ "$(diff --strip-trailing-cr <(echo "$output") "tests/expected/$output_file.log")" = "" ]
+    [ "$(diff --strip-trailing-cr "tests/output/$output_file-comp.log" "tests/expected/$output_file.log")" = "" ]
   fi
 }

--- a/tests/base.bats
+++ b/tests/base.bats
@@ -9,6 +9,8 @@ docker_test() {
   shift
   shift
   shift
+
+  # shellcheck disable=SC2086,SC2046
   run docker container run -t $docker_opts -w /data -v $(pwd)/${data_folder:-}:/data ${DOCKER_IMAGE} "$@"
 
   # shellcheck disable=SC2154

--- a/tests/base.bats
+++ b/tests/base.bats
@@ -11,8 +11,10 @@ docker_test() {
   shift
   run docker container run -t $docker_opts -w /data -v $(pwd)/${data_folder:-}:/data ${DOCKER_IMAGE} "$@"
 
+  # shellcheck disable=SC2154
   echo "$output" | tee "tests/output/$output_file.log" | sed 's#\[.*:.*/.*\..*:.*:.*\(.*\)\] ##' >"tests/output/$output_file-comp.log"
 
+  # shellcheck disable=SC2086
   [ "$status" -eq $status ]
   if [ -f "tests/expected/$output_file.log" ]; then
     [ "$(diff --strip-trailing-cr "tests/output/$output_file-comp.log" "tests/expected/$output_file.log")" = "" ]


### PR DESCRIPTION
The use of `3>&1 >&2 2>&3 3>&-` provoke the failure of the command on a GitLab environment after doing its job.

Resolves #83 