### PR TITLE
feat: update to drawio-desktop-headless docker image 1.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM rust:buster as drawio-exporter-installer
 
 RUN cargo install --version 1.2.0 drawio-exporter
 
-FROM rlespinasse/drawio-desktop-headless:v1.8.0
+FROM rlespinasse/drawio-desktop-headless:v1.10.0
 
 WORKDIR /opt/drawio-exporter
 COPY --from=drawio-exporter-installer /usr/local/cargo/bin/drawio-exporter .

--- a/README.adoc
+++ b/README.adoc
@@ -15,6 +15,10 @@ Export Draw.io diagrams using docker
 ** adoc - Export in png and create an additional asciidoc file (with support external links).
 ** md - Export in png and create an additional markdown file (with support external links).
 
+== Supported fonts formats
+
+Check installed fonts list from https://github.com/rlespinasse/docker-drawio-desktop-headless[drawio-desktop-headless] docker base image.
+
 == Installation
 
 [source,bash]


### PR DESCRIPTION
Resolves #87 