### PR TITLE
build(autoupdate): use gh release to get drawio-exporter new version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,4 +32,6 @@ test-ci:
 	@DOCKER_IMAGE=$(DOCKER_IMAGE) npx bats --verbose-run -r tests
 
 autoupdate-drawio-exporter:
-	@sed -i "s/version.*/version $(cargo search drawio-exporter -q | sed "s/.*= \"//;s/\".*//")/" Dockerfile
+	@$(eval DRAWIO_EXPORTER_RELEASE := $(shell gh release list --repo rlespinasse/drawio-exporter | grep "Latest" | cut -f1))
+	@sed -i "s/version.*/version $(DRAWIO_EXPORTER_RELEASE)/" Dockerfile
+	@test -z "${GITHUB_OUTPUT}" || echo "release_version=$(DRAWIO_DESKTOP_RELEASE)" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
Use a more resiliant method to get a new release from drawio-exporter