### PR TITLE
feat: include upstream release notes in autoupdate PRs

### DIFF
--- a/.github/workflows/autoupdate-drawio-exporter.yaml
+++ b/.github/workflows/autoupdate-drawio-exporter.yaml
@@ -31,5 +31,10 @@ jobs:
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           title: "feat: update to drawio-exporter ${{ steps.autoupdate-drawio-exporter.outputs.release_version }}"
+          body: ${{ steps.autoupdate-drawio-exporter.outputs.release_notes }}
+          commit-message: |
+            feat: update to drawio-exporter ${{ steps.autoupdate-drawio-exporter.outputs.release_version }}
+
+            ${{ steps.autoupdate-drawio-exporter.outputs.release_notes }}
           branch: autoupdate-drawio-exporter
           token: ${{ secrets.GH_TOKEN }}

--- a/justfile
+++ b/justfile
@@ -56,9 +56,20 @@ test-ci:
 [group('Maintenance mode')]
 autoupdate-drawio-exporter:
   #!/usr/bin/env bash
+  set -euo pipefail
+  CURRENT_VERSION=$(sed -n 's/.*--version \([0-9.]*\).*/\1/p' Dockerfile | head -1)
   DRAWIO_EXPORTER_RELEASE=$(gh release list --repo rlespinasse/drawio-exporter | grep "Latest" | cut -f1 | sed 's/^v//')
   sed -i "s/version.*/version $DRAWIO_EXPORTER_RELEASE/" Dockerfile
   if [ -n "${GITHUB_OUTPUT}" ]; then
     echo "release_version=$DRAWIO_EXPORTER_RELEASE" >> "${GITHUB_OUTPUT}"
+
+    RELEASE_NOTES=$(gh release view "v$DRAWIO_EXPORTER_RELEASE" --repo rlespinasse/drawio-exporter --json body -q .body)
+    {
+      echo "release_notes<<GH_RELEASE_NOTES_EOF"
+      echo "Updates \`drawio-exporter\` from \`$CURRENT_VERSION\` to \`$DRAWIO_EXPORTER_RELEASE\`."
+      echo
+      echo "$RELEASE_NOTES"
+      echo "GH_RELEASE_NOTES_EOF"
+    } >> "${GITHUB_OUTPUT}"
   fi
   echo "Updated to drawio-exporter version $DRAWIO_EXPORTER_RELEASE"


### PR DESCRIPTION
## Summary
- The `autoupdate-drawio-exporter` workflow only bumped the pinned version and opened a PR with just a title — no changelog context, unlike Dependabot PRs.
- drawio-exporter's releases already have rich, GitHub-generated notes (PR list + full changelog compare link), so this just pipes that through into the PR body / commit message.

## Test plan
- [x] Ran `just autoupdate-drawio-exporter` locally against a no-op case (already at latest) and a real bump case (1.4.1 -> 1.5.0) — verified extracted release notes
- [x] Fixed a portability bug (`grep -oP` doesn't exist on BSD/macOS grep) found while testing locally
- [ ] Verify the next scheduled `Autoupdate Drawio Exporter` run produces the expected PR body